### PR TITLE
Debug doctor data saving issue

### DIFF
--- a/PatientAppointmentSchedulingSystem/PatientAppointmentSchedulingSystem/Pages/ProviderAddDoctor.cshtml
+++ b/PatientAppointmentSchedulingSystem/PatientAppointmentSchedulingSystem/Pages/ProviderAddDoctor.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model PatientAppointmentSchedulingSystem.Pages.ProviderAddDoctorModel
 @{
     Layout = "_ProviderLayout";
@@ -45,6 +45,7 @@
                 </div>
 
                 <form method="post" novalidate>
+                    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
                     <div class="form-section">
                         <h3>Doctor Info</h3>
 

--- a/PatientAppointmentSchedulingSystem/PatientAppointmentSchedulingSystem/Pages/ProviderAddDoctor.cshtml.cs
+++ b/PatientAppointmentSchedulingSystem/PatientAppointmentSchedulingSystem/Pages/ProviderAddDoctor.cshtml.cs
@@ -7,70 +7,85 @@ using System.Security.Claims;
 
 namespace PatientAppointmentSchedulingSystem.Pages
 {
-    public class ProviderAddDoctorModel : PageModel
-    {
-        private readonly ProviderDbContext _context;
-        public ProviderAddDoctorModel(ProviderDbContext context) => _context = context;
+	public class ProviderAddDoctorModel : PageModel
+	{
+		private readonly ProviderDbContext _context;
+		public ProviderAddDoctorModel(ProviderDbContext context) => _context = context;
 
-        public List<Specialty> Specialties { get; set; } = new();
-        public string? SuccessMessage { get; set; }
+		public List<Specialty> Specialties { get; set; } = new();
+		public string? SuccessMessage { get; set; }
 
-        [BindProperty]
-        public DoctorDetails Input { get; set; } = new();
+		[BindProperty]
+		public DoctorDetails Input { get; set; } = new();
 
-        public async Task OnGetAsync()
-        {
-            Specialties = await _context.Specialty.OrderBy(s => s.SpecialtyName).ToListAsync();
-        }
-        public async Task<IActionResult> OnPostAsync()
-        {
-            Specialties = await _context.Specialty.OrderBy(s => s.SpecialtyName).ToListAsync();
-            if (!ModelState.IsValid) return Page();
+		public async Task OnGetAsync()
+		{
+			Specialties = await _context.Specialty.OrderBy(s => s.SpecialtyName).ToListAsync();
+			SuccessMessage = TempData["Success"] as string;
+		}
+		public async Task<IActionResult> OnPostAsync()
+		{
+			Specialties = await _context.Specialty.OrderBy(s => s.SpecialtyName).ToListAsync();
+			if (!ModelState.IsValid) return Page();
 
-            // ?? resolve ProviderId from claims or from email -> DB
-            var providerId = await GetProviderIdForCurrentUserAsync();
-            if (providerId == null)
-            {
-                ModelState.AddModelError("", "You must be signed in as a provider.");
-                return Page();
-            }
+			// Validate specialty selection (drop-down default is empty)
+			if (Input.SpecialtyId <= 0)
+			{
+				ModelState.AddModelError("Input.SpecialtyId", "Please select a specialty.");
+				return Page();
+			}
 
-            // ensure (ProviderId, SpecialtyId) exists due to your composite FK
-            await _context.Database.ExecuteSqlRawAsync(@"
-                IF NOT EXISTS (SELECT 1 FROM dbo.ProviderSpecialty WHERE ProviderId=@pid AND SpecialtyId=@sid)
-                    INSERT INTO dbo.ProviderSpecialty (ProviderId, SpecialtyId) VALUES (@pid, @sid);",
-                new SqlParameter("@pid", providerId),
-                new SqlParameter("@sid", Input.SpecialtyId));
+			// ?? resolve ProviderId from claims or from email -> DB
+			var providerId = await GetProviderIdForCurrentUserAsync();
+			if (providerId == null)
+			{
+				ModelState.AddModelError("", "You must be signed in as a provider.");
+				return Page();
+			}
 
-            // set ProviderId + hash password, then save
-            Input.ProviderId = providerId.Value;
-            Input.DoctorPassword = BCrypt.Net.BCrypt.HashPassword(Input.DoctorPassword);
+			// ensure (ProviderId, SpecialtyId) exists due to your composite FK
+			await _context.Database.ExecuteSqlRawAsync(@"
+				IF NOT EXISTS (SELECT 1 FROM dbo.ProviderSpecialty WHERE ProviderId=@pid AND SpecialtyId=@sid)
+					INSERT INTO dbo.ProviderSpecialty (ProviderId, SpecialtyId) VALUES (@pid, @sid);",
+				new SqlParameter("@pid", providerId),
+				new SqlParameter("@sid", Input.SpecialtyId));
 
-            _context.Doctor.Add(Input);              // DbSet<DoctorDetails> Doctor { get; set; }
-            await _context.SaveChangesAsync();
+			// set ProviderId + hash password, then save
+			Input.ProviderId = providerId.Value;
+			Input.DoctorPassword = BCrypt.Net.BCrypt.HashPassword(Input.DoctorPassword);
 
-            TempData["Success"] = $"Doctor saved (ID #{Input.DoctorId}).";
-            return RedirectToPage("/ProviderAddDoctor");
-        }
+			_context.Doctor.Add(Input);              // DbSet<DoctorDetails> Doctor { get; set; }
+			await _context.SaveChangesAsync();
 
-        private async Task<int?> GetProviderIdForCurrentUserAsync()
-        {
-            // Prefer explicit ProviderId claim if present
-            if (int.TryParse(User.FindFirstValue("ProviderId"), out var pidFromClaim))
-                return pidFromClaim;
+			TempData["Success"] = $"Doctor saved (ID #{Input.DoctorId}).";
+			return RedirectToPage("/ProviderAddDoctor");
+		}
 
-            // Otherwise resolve via email claim (or Name)
-            var email = User.FindFirstValue(ClaimTypes.Email) ?? User.Identity?.Name;
-            if (!string.IsNullOrWhiteSpace(email))
-            {
-                return await _context.Provider
-                    .Where(p => p.Email == email)
-                    .Select(p => (int?)p.ProviderId)
-                    .FirstOrDefaultAsync();
-            }
-            return null;
-        }
+		private async Task<int?> GetProviderIdForCurrentUserAsync()
+		{
+			// Prefer explicit ProviderId claim if present
+			if (int.TryParse(User.FindFirstValue("ProviderId"), out var pidFromClaim))
+				return pidFromClaim;
+
+			// Otherwise resolve via email claim (or Name)
+			var email = User.FindFirstValue(ClaimTypes.Email) ?? User.Identity?.Name;
+			if (!string.IsNullOrWhiteSpace(email))
+			{
+				var providerIdFromEmail = await _context.Provider
+					.Where(p => p.Email == email)
+					.Select(p => (int?)p.ProviderId)
+					.FirstOrDefaultAsync();
+				if (providerIdFromEmail != null)
+					return providerIdFromEmail;
+			}
+
+			// Fallback to static ProviderSession used by ProviderLogin
+			if (ProviderSession.ProviderId > 0)
+				return ProviderSession.ProviderId;
+
+			return null;
+		}
 
 
-    }
+	}
 }


### PR DESCRIPTION
Fix doctor data not saving by resolving `ProviderId` from `ProviderSession` and adding specialty selection validation.

The `ProviderAddDoctor` page was failing to save doctor data because it incorrectly tried to resolve the `ProviderId` from authentication claims, while the `ProviderLogin` page stores it in `ProviderSession.ProviderId`. This PR updates the `GetProviderIdForCurrentUserAsync` method to correctly use `ProviderSession.ProviderId` as a fallback, and adds a validation check to ensure a specialty is selected before saving. It also improves user feedback by displaying validation summaries and success messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-1116d95a-4afe-4916-a9c0-f341ea25ba51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1116d95a-4afe-4916-a9c0-f341ea25ba51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

